### PR TITLE
fix(finnish): Handle undefined type symbol

### DIFF
--- a/source/rules/rxjsFinnishRule.ts
+++ b/source/rules/rxjsFinnishRule.ts
@@ -196,7 +196,7 @@ class Walker extends Lint.ProgramAwareRuleWalker {
                 }
                 for (let i = 0; i < this.types.length; ++i) {
                     const { regExp, validate } = this.types[i];
-                    if (regExp.test(type.symbol.name) && !validate) {
+                    if (type.symbol !== undefined && regExp.test(type.symbol.name) && !validate) {
                         return;
                     }
                 }

--- a/test/v5/fixtures/finnish/optional/fixture.ts.lint
+++ b/test/v5/fixtures/finnish/optional/fixture.ts.lint
@@ -1,0 +1,8 @@
+import { Observable, of } from "rxjs";
+
+const someOptionalObservable$: Observable<any> | undefined = of();
+
+const someOptionalObservable: Observable<any> | undefined = of();
+      ~~~~~~~~~~~~~~~~~~~~~~                                                                [finnish % ("someOptionalObservable")]
+
+[finnish]: Finnish notation required for %s

--- a/test/v5/fixtures/finnish/optional/tsconfig.json
+++ b/test/v5/fixtures/finnish/optional/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "lib": ["es2015"],
+    "noEmit": true,
+    "paths": {
+      "rxjs": ["../../node_modules/rxjs"]
+    },
+    "skipLibCheck": true,
+    "target": "es5",
+    "strictNullChecks": true
+  },
+  "include": ["fixture.ts"]
+}

--- a/test/v5/fixtures/finnish/optional/tslint.json
+++ b/test/v5/fixtures/finnish/optional/tslint.json
@@ -1,0 +1,8 @@
+{
+  "defaultSeverity": "error",
+  "jsRules": {},
+  "rules": {
+    "rxjs-finnish": { "severity": "error" }
+  },
+  "rulesDirectory": "../../../../../build/rules"
+}

--- a/test/v6-compat/fixtures/finnish/optional/fixture.ts.lint
+++ b/test/v6-compat/fixtures/finnish/optional/fixture.ts.lint
@@ -1,0 +1,8 @@
+import { Observable, of } from "rxjs";
+
+const someOptionalObservable$: Observable<any> | undefined = of();
+
+const someOptionalObservable: Observable<any> | undefined = of();
+      ~~~~~~~~~~~~~~~~~~~~~~                                                                [finnish % ("someOptionalObservable")]
+
+[finnish]: Finnish notation required for %s

--- a/test/v6-compat/fixtures/finnish/optional/tsconfig.json
+++ b/test/v6-compat/fixtures/finnish/optional/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "lib": ["es2015"],
+    "noEmit": true,
+    "paths": {
+      "rxjs": ["../../node_modules/rxjs"]
+    },
+    "skipLibCheck": true,
+    "target": "es5",
+    "strictNullChecks": true
+  },
+  "include": ["fixture.ts"]
+}

--- a/test/v6-compat/fixtures/finnish/optional/tslint.json
+++ b/test/v6-compat/fixtures/finnish/optional/tslint.json
@@ -1,0 +1,8 @@
+{
+  "defaultSeverity": "error",
+  "jsRules": {},
+  "rules": {
+    "rxjs-finnish": { "severity": "error" }
+  },
+  "rulesDirectory": "../../../../../build/rules"
+}

--- a/test/v6/fixtures/finnish/optional/fixture.ts.lint
+++ b/test/v6/fixtures/finnish/optional/fixture.ts.lint
@@ -1,0 +1,8 @@
+import { Observable, of } from "rxjs";
+
+const someOptionalObservable$: Observable<any> | undefined = of();
+
+const someOptionalObservable: Observable<any> | undefined = of();
+      ~~~~~~~~~~~~~~~~~~~~~~                                                                [finnish % ("someOptionalObservable")]
+
+[finnish]: Finnish notation required for %s

--- a/test/v6/fixtures/finnish/optional/tsconfig.json
+++ b/test/v6/fixtures/finnish/optional/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "lib": ["es2015"],
+    "noEmit": true,
+    "paths": {
+      "rxjs": ["../../node_modules/rxjs"]
+    },
+    "skipLibCheck": true,
+    "target": "es5",
+    "strictNullChecks": true
+  },
+  "include": ["fixture.ts"]
+}

--- a/test/v6/fixtures/finnish/optional/tslint.json
+++ b/test/v6/fixtures/finnish/optional/tslint.json
@@ -1,0 +1,8 @@
+{
+  "defaultSeverity": "error",
+  "jsRules": {},
+  "rules": {
+    "rxjs-finnish": { "severity": "error" }
+  },
+  "rulesDirectory": "../../../../../build/rules"
+}


### PR DESCRIPTION
Took a stab at this. I added a separate test case, so as to not "pollute" the other test fixtures with `strictNullChecks`.

Closes #45 