### PR TITLE
Fix no ignored replay buffer edge cases

### DIFF
--- a/test/v6/fixtures/no-ignored-replay-buffer/default/fixture.ts.lint
+++ b/test/v6/fixtures/no-ignored-replay-buffer/default/fixture.ts.lint
@@ -13,4 +13,8 @@ const e = of(42).pipe(shareReplay(1));
 const f = of(42).pipe(shareReplay());
                       ~~~~~~~~~~~           [no-ignored-replay-buffer]
 
+const g = new Thing(new ReplaySubject<number>(1));
+const h = new Thing(new ReplaySubject<number>());
+                        ~~~~~~~~~~~~~       [no-ignored-replay-buffer]
+
 [no-ignored-replay-buffer]: Ignoring the buffer size is forbidden

--- a/test/v6/fixtures/no-ignored-replay-buffer/diff-import-alias/fixture.ts.lint
+++ b/test/v6/fixtures/no-ignored-replay-buffer/diff-import-alias/fixture.ts.lint
@@ -1,0 +1,30 @@
+import * as Rx from "rxjs";
+import { publishReplay, shareReplay } from "rxjs/operators";
+
+const a = new Rx.ReplaySubject<string>(1);
+const b = new Rx.ReplaySubject<string>();
+                 ~~~~~~~~~~~~~                 [no-ignored-replay-buffer]
+
+const c = Rx.of(42).pipe(publishReplay(1));
+const d = Rx.of(42).pipe(publishReplay());
+                         ~~~~~~~~~~~~~         [no-ignored-replay-buffer]
+
+const e = Rx.of(42).pipe(shareReplay(1));
+const f = Rx.of(42).pipe(shareReplay());
+                         ~~~~~~~~~~~           [no-ignored-replay-buffer]
+
+
+const g = new Thing(new Rx.ReplaySubject<number>(1));
+const g = new Thing(new Rx.ReplaySubject<number>());
+                           ~~~~~~~~~~~~~        [no-ignored-replay-buffer]
+class Mock {
+    private valid: Rx.ReplaySubject<number>;
+    private invalid: Rx.ReplaySubject<number>
+
+    constructor(){
+        this.valid = new Rx.ReplaySubject<number>(1);
+        this.invalid = new Rx.ReplaySubject<number>();
+                              ~~~~~~~~~~~~~    [no-ignored-replay-buffer]
+    }
+}
+[no-ignored-replay-buffer]: Ignoring the buffer size is forbidden

--- a/test/v6/fixtures/no-ignored-replay-buffer/diff-import-alias/tsconfig.json
+++ b/test/v6/fixtures/no-ignored-replay-buffer/diff-import-alias/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "lib": ["es2015"],
+    "noEmit": true,
+    "paths": {
+      "rxjs": ["../../node_modules/rxjs"]
+    },
+    "skipLibCheck": true,
+    "target": "es5"
+  },
+  "include": ["fixture.ts"]
+}

--- a/test/v6/fixtures/no-ignored-replay-buffer/diff-import-alias/tslint.json
+++ b/test/v6/fixtures/no-ignored-replay-buffer/diff-import-alias/tslint.json
@@ -1,0 +1,8 @@
+{
+  "defaultSeverity": "error",
+  "jsRules": {},
+  "rules": {
+    "rxjs-no-ignored-replay-buffer": { "severity": "error" }
+  },
+  "rulesDirectory": "../../../../../build/rules"
+}


### PR DESCRIPTION
Queries for Identifiers under these two cases:

1. `NewExpression > Identifier[name="ReplaySubject"]`, getting the direct identifier of a new expression
2. `NewExpression PropertyAccessExpression Identifier[name="ReplaySubject"]`