### PR TITLE
Add fix to rxjs-no-explicit-generics rule

### DIFF
--- a/source/rules/rxjsNoExplicitGenericsRule.ts
+++ b/source/rules/rxjsNoExplicitGenericsRule.ts
@@ -45,15 +45,28 @@ export class Rule extends Lint.Rules.AbstractRule {
       ) as ts.Identifier[])
     );
 
-    return identifiers.map(
-      identifier =>
-        new Lint.RuleFailure(
-          sourceFile,
-          identifier.getStart(),
-          identifier.getStart() + identifier.getWidth(),
-          Rule.FAILURE_STRING,
-          this.ruleName
-        )
-    );
+    return identifiers.map(identifier => {
+      const identifierLoc = identifier.parent.getChildren().indexOf(identifier);
+      const typeArgumentStart = identifier.parent
+        .getChildAt(identifierLoc + 1)
+        .getStart();
+      const typeArgumentEnd = identifier.parent
+        .getChildAt(identifierLoc + 3)
+        .getEnd();
+      const fix = Lint.Replacement.replaceFromTo(
+        typeArgumentStart,
+        typeArgumentEnd,
+        ""
+      );
+
+      return new Lint.RuleFailure(
+        sourceFile,
+        identifier.getStart(),
+        identifier.getStart() + identifier.getWidth(),
+        Rule.FAILURE_STRING,
+        this.ruleName,
+        fix
+      );
+    });
   }
 }

--- a/test/v6/fixtures/no-explicit-generics/default/fixture.ts.fix
+++ b/test/v6/fixtures/no-explicit-generics/default/fixture.ts.fix
@@ -1,0 +1,23 @@
+import { BehaviorSubject, from, of } from "rxjs";
+import { scan } from "rxjs/operators";
+
+const a = of(42, 54);
+const b = a.pipe(
+    scan((acc, value) => `${acc},${value}`, "")
+);
+const c = a.pipe(
+    scan((acc: string, value: number) => `${acc},${value}`, "")
+);
+const c2 = a.pipe(
+    scan((acc, value): string => `${acc},${value}`, "")
+);
+
+const d = new BehaviorSubject(42);
+const e = new BehaviorSubject(42);
+
+const f = from([42, 54]);
+const g = from([42, 54]);
+
+const h = of(42, 54);
+const i = of(42, 54);
+


### PR DESCRIPTION
If the code says for example `new BehaviorSubject<number>(1)`, the lint message should suggest correcting it to `new BehaviorSubject(1)`